### PR TITLE
Update design tokens.

### DIFF
--- a/Inspector/Inspector.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Inspector/Inspector.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/compound-design-tokens.git",
       "state" : {
-        "revision" : "f006a14218e279f81f2ab9398d8ebae58e87e25f",
-        "version" : "0.1.1"
+        "revision" : "d7c3bba963d6b7ffab862c3293eb242a8932a0c1",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/compound-design-tokens.git",
       "state" : {
-        "revision" : "f006a14218e279f81f2ab9398d8ebae58e87e25f",
-        "version" : "0.1.1"
+        "revision" : "d7c3bba963d6b7ffab862c3293eb242a8932a0c1",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .library(name: "Compound", targets: ["Compound"])
     ],
     dependencies: [
-        .package(url: "https://github.com/element-hq/compound-design-tokens.git", exact: "0.1.1"),
+        .package(url: "https://github.com/element-hq/compound-design-tokens.git", exact: "1.0.0"),
         .package(url: "https://github.com/siteline/SwiftUI-Introspect.git", from: "0.9.0"),
         .package(url: "https://github.com/SFSafeSymbols/SFSafeSymbols.git", from: "4.1.1"),
         .package(url: "https://github.com/BarredEwe/Prefire", from: "1.5.0"),


### PR DESCRIPTION
This PR pulls in the latest version of the design tokens package. Its updates the icons and adds new decorative colours. The decorative colours will be a follow-up PR that we can do at the same time as Web and Android (as they replace avatar colours and reduce the number of options from 8 to 6).

A few snapshots needed regenerating for the latest round of icon updates - you can't see the change in the diffs which is a bit surprising given we have lowered perceptual precision 🤷‍♂️