### PR TITLE
Codecov: Move to codecov-action v4 and fix coverage report

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,8 +41,10 @@ jobs:
         if-no-files-found: ignore
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
+        fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}
         xcode: true
         xcode_archive_path: Logs/CompoundTests.xcresult
  


### PR DESCRIPTION
Codecov got a report with this change: https://app.codecov.io/github/element-hq/compound-ios/pull/69

Compared to builds made in the last 2 weeks:
<img width="1035" alt="image" src="https://github.com/element-hq/compound-ios/assets/8418515/ad943cdd-cc61-4821-a423-fdc24c302829">
