### PR TITLE
Add support for customising specific colours.

### DIFF
--- a/Inspector/Inspector.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Inspector/Inspector.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/compound-design-tokens.git",
       "state" : {
-        "revision" : "df53a1a8804b90b6a1f2a290fa6d1c2977c317ec",
-        "version" : "1.4.0"
+        "revision" : "b1e0643d0af145a00297190ca0e6dc48cbe5ace0",
+        "version" : "1.5.0"
       }
     },
     {

--- a/Inspector/Sources/Tokens/AllCases.swift
+++ b/Inspector/Sources/Tokens/AllCases.swift
@@ -8,50 +8,38 @@
 import Compound
 import SwiftUI
 
-extension CompoundColors {
-    var allColors: [(name: String, value: Color)] {
-        var colors: [(name: String, value: Color)] = []
+protocol AllValues {
+    associatedtype ValueType
+    var allValues: [(name: String, value: ValueType)] { get }
+}
+
+extension AllValues {
+    var allValues: [(name: String, value: ValueType)] {
+        var values: [(name: String, value: ValueType)] = []
         let mirror = Mirror(reflecting: self)
         
         for property in mirror.children {
-            if let label = property.label, let color = property.value as? Color {
-                colors.append((label, color))
+            if let label = property.label, let value = property.value as? ValueType {
+                values.append((label, value))
             }
         }
         
-        return colors
+        return values
     }
 }
 
-extension CompoundFonts {
-    var allFonts: [(name: String, value: Font)] {
-        var fonts: [(name: String, value: Font)] = []
-        let mirror = Mirror(reflecting: self)
-        
-        for property in mirror.children {
-            if let label = property.label, let font = property.value as? Font {
-                fonts.append((label, font))
-            }
-        }
-        
-        return fonts
+extension CompoundColors: AllValues { typealias ValueType = Color }
+extension CompoundColorTokens: AllValues { typealias ValueType = Color }
+extension CompoundFonts: AllValues { typealias ValueType = Font }
+extension CompoundIcons: AllValues { typealias ValueType = Image }
+
+extension CompoundColors {
+    var allColors: [(name: String, value: Color)] {
+        CompoundColorTokens().allValues + allValues
     }
 }
 
 extension CompoundIcons {
-    var allIcons: [(name: String, value: Image)] {
-        var icons: [(name: String, value: Image)] = []
-        let mirror = Mirror(reflecting: self)
-        
-        for property in mirror.children {
-            if let label = property.label, let icon = property.value as? Image {
-                icons.append((label, icon))
-            }
-        }
-        
-        return icons
-    }
-    
     var allKeyPaths: [(name: String, value: KeyPath<CompoundIcons, Image>)] {
         var icons: [(name: String, value: KeyPath<CompoundIcons, Image>)] = []
         let mirror = Mirror(reflecting: self)

--- a/Inspector/Sources/Tokens/FontsScreen.swift
+++ b/Inspector/Sources/Tokens/FontsScreen.swift
@@ -11,7 +11,7 @@ import Compound
 struct FontsScreen: View {
     var body: some View {
         ScreenContent(navigationTitle: "Fonts") {
-            ForEach(Font.compound.allFonts, id: \.name) { font in
+            ForEach(Font.compound.allValues, id: \.name) { font in
                 FontItem(font: font.value, name: font.name)
             }
         }

--- a/Inspector/Sources/Tokens/IconsScreen.swift
+++ b/Inspector/Sources/Tokens/IconsScreen.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import Compound
 
 struct IconsScreen: View {
-    let icons = Image.compound.allIcons.sorted(by: { $0.name < $1.name })
+    let icons = Image.compound.allValues.sorted(by: { $0.name < $1.name })
     
     var body: some View {
         ScreenContent(navigationTitle: "Icons") {

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,10 +3,10 @@
     {
       "identity" : "compound-design-tokens",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/element-hq/compound-design-tokens.git",
+      "location" : "https://github.com/element-hq/compound-design-tokens",
       "state" : {
-        "revision" : "df53a1a8804b90b6a1f2a290fa6d1c2977c317ec",
-        "version" : "1.4.0"
+        "revision" : "b1e0643d0af145a00297190ca0e6dc48cbe5ace0",
+        "version" : "1.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .library(name: "Compound", targets: ["Compound"])
     ],
     dependencies: [
-        .package(url: "https://github.com/element-hq/compound-design-tokens", exact: "1.4.0"),
+        .package(url: "https://github.com/element-hq/compound-design-tokens", exact: "1.5.0"),
         .package(url: "https://github.com/siteline/SwiftUI-Introspect", from: "1.2.0"),
         .package(url: "https://github.com/SFSafeSymbols/SFSafeSymbols", from: "5.3.0"),
         .package(url: "https://github.com/BarredEwe/Prefire", from: "2.8.0"),

--- a/Sources/Compound/Colors/CompoundColors.swift
+++ b/Sources/Compound/Colors/CompoundColors.swift
@@ -29,89 +29,44 @@ public extension ShapeStyle where Self == Color {
 
 /// The colours used by Element as defined in Compound Design Tokens.
 /// This struct contains only the colour tokens in a more usable form.
-public struct CompoundColors {
-    /// The raw compound tokens.
+@dynamicMemberLookup
+public class CompoundColors {
+    /// The base colour tokens that form the palette of available colours.
     ///
-    /// Note: Whilst this references `CompoundLightDesignTokens`, all generated tokens are aware
-    /// of dark and high contract variants the generated collections each contain the same token set.
-    private static let compound = CompoundColorTokens.self
+    /// Normally these shouldn't be necessary, however in practice we may need
+    /// access for temporary tokens while waiting for official ones to be formalised.
+    private static let coreTokens = CompoundCoreColorTokens.self
+    /// The main semantic tokens generated from the Style Dictionary.
+    private let tokens: CompoundColorTokens
     
-    public let iconOnSolidPrimary = compound.colorIconOnSolidPrimary
-    public let iconInfoPrimary = compound.colorIconInfoPrimary
-    public let iconSuccessPrimary = compound.colorIconSuccessPrimary
-    public let iconCriticalPrimary = compound.colorIconCriticalPrimary
-    public let iconAccentPrimary = compound.colorIconAccentPrimary
-    public let iconAccentTertiary = compound.colorIconAccentTertiary
-    public let iconQuaternaryAlpha = compound.colorIconQuaternaryAlpha
-    public let iconTertiaryAlpha = compound.colorIconTertiaryAlpha
-    public let iconSecondaryAlpha = compound.colorIconSecondaryAlpha
-    public let iconPrimaryAlpha = compound.colorIconPrimaryAlpha
-    public let iconDisabled = compound.colorIconDisabled
-    public let iconQuaternary = compound.colorIconQuaternary
-    public let iconTertiary = compound.colorIconTertiary
-    public let iconSecondary = compound.colorIconSecondary
-    public let iconPrimary = compound.colorIconPrimary
-    public let borderInfoSubtle = compound.colorBorderInfoSubtle
-    public let borderSuccessSubtle = compound.colorBorderSuccessSubtle
-    public let borderCriticalSubtle = compound.colorBorderCriticalSubtle
-    public let borderCriticalHovered = compound.colorBorderCriticalHovered
-    public let borderCriticalPrimary = compound.colorBorderCriticalPrimary
-    public let borderInteractiveHovered = compound.colorBorderInteractiveHovered
-    public let borderInteractiveSecondary = compound.colorBorderInteractiveSecondary
-    public let borderInteractivePrimary = compound.colorBorderInteractivePrimary
-    public let borderFocused = compound.colorBorderFocused
-    public let borderDisabled = compound.colorBorderDisabled
-    // public let bgSubtleSecondaryLevel0 = compound.colorBgSubtleSecondaryLevel0
-    public let bgAccentPressed = compound.colorBgAccentPressed
-    public let bgAccentHovered = compound.colorBgAccentHovered
-    public let bgAccentRest = compound.colorBgAccentRest
-    public let bgInfoSubtle = compound.colorBgInfoSubtle
-    public let bgSuccessSubtle = compound.colorBgSuccessSubtle
-    public let bgCriticalSubtleHovered = compound.colorBgCriticalSubtleHovered
-    public let bgCriticalSubtle = compound.colorBgCriticalSubtle
-    public let bgCriticalHovered = compound.colorBgCriticalHovered
-    public let bgCriticalPrimary = compound.colorBgCriticalPrimary
-    public let bgActionSecondaryPressed = compound.colorBgActionSecondaryPressed
-    public let bgActionSecondaryHovered = compound.colorBgActionSecondaryHovered
-    public let bgActionSecondaryRest = compound.colorBgActionSecondaryRest
-    public let bgActionPrimaryDisabled = compound.colorBgActionPrimaryDisabled
-    public let bgActionPrimaryPressed = compound.colorBgActionPrimaryPressed
-    public let bgActionPrimaryHovered = compound.colorBgActionPrimaryHovered
-    public let bgActionPrimaryRest = compound.colorBgActionPrimaryRest
-    // public let bgCanvasDefaultLevel1 = compound.colorBgCanvasDefaultLevel1
-    public let bgCanvasDisabled = compound.colorBgCanvasDisabled
-    public let bgCanvasDefault = compound.colorBgCanvasDefault
-    public let bgSubtleSecondary = compound.colorBgSubtleSecondary
-    public let bgSubtlePrimary = compound.colorBgSubtlePrimary
-    public let textOnSolidPrimary = compound.colorTextOnSolidPrimary
-    public let textInfoPrimary = compound.colorTextInfoPrimary
-    public let textSuccessPrimary = compound.colorTextSuccessPrimary
-    public let textCriticalPrimary = compound.colorTextCriticalPrimary
-    public let textLinkExternal = compound.colorTextLinkExternal
-    public let textActionAccent = compound.colorTextActionAccent
-    public let textActionPrimary = compound.colorTextActionPrimary
-    public let textDisabled = compound.colorTextDisabled
-    public let textPlaceholder = compound.colorTextPlaceholder
-    public let textSecondary = compound.colorTextSecondary
-    public let textPrimary = compound.colorTextPrimary
+    public subscript(dynamicMember keyPath: KeyPath<CompoundColorTokens, Color>) -> Color {
+        return tokens[keyPath: keyPath]
+    }
+    
+    init() {
+        let tokens = CompoundColorTokens()
+        self.tokens = tokens
+        
+        decorativeColors = [
+           .init(background: tokens.bgDecorative1, text: tokens.textDecorative1),
+           .init(background: tokens.bgDecorative2, text: tokens.textDecorative2),
+           .init(background: tokens.bgDecorative3, text: tokens.textDecorative3),
+           .init(background: tokens.bgDecorative4, text: tokens.textDecorative4),
+           .init(background: tokens.bgDecorative5, text: tokens.textDecorative5),
+           .init(background: tokens.bgDecorative6, text: tokens.textDecorative6),
+       ]
+    }
     
     // MARK: - Elevation Tokens
     // This is a workaround until they are generated correctly
     
-    public let bgSubtleSecondaryLevel0 = Color(UIColor { $0.isLight ? UIColor(compound.colorGray300) : UIColor(compound.colorThemeBg) })
-    public let bgCanvasDefaultLevel1 = Color(UIColor { $0.isLight ? UIColor(compound.colorThemeBg) : UIColor(compound.colorGray300) })
+    public let bgSubtleSecondaryLevel0 = Color(UIColor { $0.isLight ? UIColor(coreTokens.gray300) : UIColor(coreTokens.themeBg) })
+    public let bgCanvasDefaultLevel1 = Color(UIColor { $0.isLight ? UIColor(coreTokens.themeBg) : UIColor(coreTokens.gray300) })
     
     // MARK: - Decorative Colors
     // Used to determine the background and text colors of avatars, usernames etc.
-    internal let decorativeColors: [DecorativeColor] = [
-        // TODO: Use decorative colours
-        .init(background: compound.colorBgDecorative1, text: compound.colorTextDecorative1),
-        .init(background: compound.colorBgDecorative2, text: compound.colorTextDecorative2),
-        .init(background: compound.colorBgDecorative3, text: compound.colorTextDecorative3),
-        .init(background: compound.colorBgDecorative4, text: compound.colorTextDecorative4),
-        .init(background: compound.colorBgDecorative5, text: compound.colorTextDecorative5),
-        .init(background: compound.colorBgDecorative6, text: compound.colorTextDecorative6),
-    ]
+    
+    let decorativeColors: [DecorativeColor]
     
     public func decorativeColor(for contentID: String) -> DecorativeColor {
         decorativeColors[contentID.hashCode]
@@ -121,58 +76,56 @@ public struct CompoundColors {
     
     /// This token is a placeholder and hasn't been finalised.
     @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _borderTextFieldFocused = compound.colorGray500
+    public let _borderTextFieldFocused = coreTokens.gray500
     /// This token is a placeholder and hasn't been finalised.
     @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _bgReactionButton = Color(UIColor { $0.isLight ? UIColor(compound.colorGray200) : UIColor(compound.colorGray600) })
+    public let _bgBubbleIncoming = Color(UIColor { $0.isLight ? UIColor(coreTokens.gray300) : UIColor(coreTokens.gray400) })
     /// This token is a placeholder and hasn't been finalised.
     @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _bgBubbleIncoming = Color(UIColor { $0.isLight ? UIColor(compound.colorGray300) : UIColor(compound.colorGray400) })
+    public let _bgBubbleOutgoing = Color(UIColor { $0.isLight ? UIColor(coreTokens.gray400) : UIColor(coreTokens.gray500) })
     /// This token is a placeholder and hasn't been finalised.
     @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _bgBubbleOutgoing = Color(UIColor { $0.isLight ? UIColor(compound.colorGray400) : UIColor(compound.colorGray500) })
+    public let _bgBubbleHighlighted = coreTokens.green300
     /// This token is a placeholder and hasn't been finalised.
     @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _bgBubbleHighlighted = compound.colorGreen300
+    public let _bgCodeBlock = coreTokens.gray100
     /// This token is a placeholder and hasn't been finalised.
     @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _bgCodeBlock = compound.colorGray100
+    public let _borderInteractiveSecondaryAlpha = coreTokens.alphaGray600
     /// This token is a placeholder and hasn't been finalised.
     @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _borderInteractiveSecondaryAlpha = compound.colorAlphaGray600
+    public let _bgSubtleSecondaryAlpha = coreTokens.alphaGray300
     /// This token is a placeholder and hasn't been finalised.
     @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _bgSubtleSecondaryAlpha = compound.colorAlphaGray300
+    public let _bgCriticalSubtleAlpha = coreTokens.alphaRed300
     /// This token is a placeholder and hasn't been finalised.
     @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _bgCriticalSubtleAlpha = compound.colorAlphaRed300
+    public let _bgEmptyItemAlpha = coreTokens.alphaGray500
     /// This token is a placeholder and hasn't been finalised.
     @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _bgEmptyItemAlpha = compound.colorAlphaGray500
+    public let _bgAccentSelected = coreTokens.green300
     /// This token is a placeholder and hasn't been finalised.
     @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _bgAccentSelected = compound.colorGreen300
+    public let _bgPill = Color(UIColor { $0.isLight ? UIColor(coreTokens.alphaGray400) : UIColor(coreTokens.alphaGray500) })
     /// This token is a placeholder and hasn't been finalised.
     @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _bgPill = Color(UIColor { $0.isLight ? UIColor(compound.colorAlphaGray400) : UIColor(compound.colorAlphaGray500) })
+    public let _bgOwnPill = Color(UIColor { $0.isLight ? UIColor(coreTokens.alphaGreen400) : UIColor(coreTokens.alphaGreen500) })
     /// This token is a placeholder and hasn't been finalised.
     @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _bgOwnPill = Color(UIColor { $0.isLight ? UIColor(compound.colorAlphaGreen400) : UIColor(compound.colorAlphaGreen500) })
+    public let _textOwnPill = coreTokens.green1100
     /// This token is a placeholder and hasn't been finalised.
     @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _textOwnPill = compound.colorGreen1100
+    public let _bgBadgeSuccess = coreTokens.alphaGreen300
     /// This token is a placeholder and hasn't been finalised.
     @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _bgBadgeSuccess = compound.colorAlphaGreen300
+    public let _badgeTextSubtle = coreTokens.gray1100
     /// This token is a placeholder and hasn't been finalised.
     @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _badgeTextSubtle = compound.colorGray1100
-    /// This token is a placeholder and hasn't been finalised.
-    @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _badgeTextSuccess = compound.colorGreen1100
+    public let _badgeTextSuccess = coreTokens.green1100
     
     // MARK: - Gradients
-    public let gradientSuperButton = Gradient(colors: [compound.colorBlue900, compound.colorGreen1100])
+    
+    public let gradientSuperButton = Gradient(colors: [coreTokens.blue900, coreTokens.green1100])
 }
 
 private extension UITraitCollection {

--- a/Sources/Compound/Colors/CompoundColors.swift
+++ b/Sources/Compound/Colors/CompoundColors.swift
@@ -38,9 +38,17 @@ public class CompoundColors {
     private static let coreTokens = CompoundCoreColorTokens.self
     /// The main semantic tokens generated from the Style Dictionary.
     private let tokens: CompoundColorTokens
+    /// Runtime overrides for the `tokens` property.
+    private var overrides = [KeyPath<CompoundColorTokens, Color>: Color]()
     
     public subscript(dynamicMember keyPath: KeyPath<CompoundColorTokens, Color>) -> Color {
-        return tokens[keyPath: keyPath]
+        return overrides[keyPath] ?? tokens[keyPath: keyPath]
+    }
+    
+    /// Customise the colour at the specified key path with the supplied colour.
+    /// Supplying `nil` as the colour will remove any existing customisation.
+    public func override(_ keyPath: KeyPath<CompoundColorTokens, Color>, with color: Color?) {
+        overrides[keyPath] = color
     }
     
     init() {

--- a/Sources/Compound/Colors/CompoundUIColors.swift
+++ b/Sources/Compound/Colors/CompoundUIColors.swift
@@ -33,9 +33,17 @@ public class CompoundUIColors {
     private static let coreTokens = CompoundCoreUIColorTokens.self
     /// The main semantic tokens generated from the Style Dictionary.
     private let tokens = CompoundUIColorTokens()
+    /// Runtime overrides for the `tokens` property.
+    private var overrides = [KeyPath<CompoundUIColorTokens, UIColor>: UIColor]()
     
     public subscript(dynamicMember keyPath: KeyPath<CompoundUIColorTokens, UIColor>) -> UIColor {
-        return tokens[keyPath: keyPath]
+        return overrides[keyPath] ?? tokens[keyPath: keyPath]
+    }
+    
+    /// Customise the colour at the specified key path with the supplied colour.
+    /// Supplying `nil` as the colour will remove any existing customisation.
+    public func override(_ keyPath: KeyPath<CompoundUIColorTokens, UIColor>, with color: UIColor?) {
+        overrides[keyPath] = color
     }
     
     // MARK: - Elevation Tokens

--- a/Sources/Compound/Colors/CompoundUIColors.swift
+++ b/Sources/Compound/Colors/CompoundUIColors.swift
@@ -24,105 +24,34 @@ public extension UIColor {
 
 /// The colours used by Element as defined in Compound Design Tokens.
 /// This struct contains only the colour tokens in a more usable form.
-public struct CompoundUIColors {
-    /// The raw compound tokens.
+@dynamicMemberLookup
+public class CompoundUIColors {
+    /// The base colour tokens that form the palette of available colours.
     ///
-    /// Note: Whilst this references `CompoundLightDesignTokens`, all generated tokens are aware
-    /// of dark and high contract variants the generated collections each contain the same token set.
-    private static let compound = CompoundUIColorTokens.self
+    /// Normally these shouldn't be necessary, however in practice we may need
+    /// access for temporary tokens while waiting for official ones to be formalised.
+    private static let coreTokens = CompoundCoreUIColorTokens.self
+    /// The main semantic tokens generated from the Style Dictionary.
+    private let tokens = CompoundUIColorTokens()
     
-    public let iconOnSolidPrimary = compound.colorIconOnSolidPrimary
-    public let iconInfoPrimary = compound.colorIconInfoPrimary
-    public let iconSuccessPrimary = compound.colorIconSuccessPrimary
-    public let iconCriticalPrimary = compound.colorIconCriticalPrimary
-    public let iconAccentPrimary = compound.colorIconAccentPrimary
-    public let iconAccentTertiary = compound.colorIconAccentTertiary
-    public let iconQuaternaryAlpha = compound.colorIconQuaternaryAlpha
-    public let iconTertiaryAlpha = compound.colorIconTertiaryAlpha
-    public let iconSecondaryAlpha = compound.colorIconSecondaryAlpha
-    public let iconPrimaryAlpha = compound.colorIconPrimaryAlpha
-    public let iconDisabled = compound.colorIconDisabled
-    public let iconQuaternary = compound.colorIconQuaternary
-    public let iconTertiary = compound.colorIconTertiary
-    public let iconSecondary = compound.colorIconSecondary
-    public let iconPrimary = compound.colorIconPrimary
-    public let borderInfoSubtle = compound.colorBorderInfoSubtle
-    public let borderSuccessSubtle = compound.colorBorderSuccessSubtle
-    public let borderCriticalSubtle = compound.colorBorderCriticalSubtle
-    public let borderCriticalHovered = compound.colorBorderCriticalHovered
-    public let borderCriticalPrimary = compound.colorBorderCriticalPrimary
-    public let borderInteractiveHovered = compound.colorBorderInteractiveHovered
-    public let borderInteractiveSecondary = compound.colorBorderInteractiveSecondary
-    public let borderInteractivePrimary = compound.colorBorderInteractivePrimary
-    public let borderFocused = compound.colorBorderFocused
-    public let borderDisabled = compound.colorBorderDisabled
-    // public let bgSubtleSecondaryLevel0 = compound.colorBgSubtleSecondaryLevel0
-    public let bgAccentPressed = compound.colorBgAccentPressed
-    public let bgAccentHovered = compound.colorBgAccentHovered
-    public let bgAccentRest = compound.colorBgAccentRest
-    public let bgInfoSubtle = compound.colorBgInfoSubtle
-    public let bgSuccessSubtle = compound.colorBgSuccessSubtle
-    public let bgCriticalSubtleHovered = compound.colorBgCriticalSubtleHovered
-    public let bgCriticalSubtle = compound.colorBgCriticalSubtle
-    public let bgCriticalHovered = compound.colorBgCriticalHovered
-    public let bgCriticalPrimary = compound.colorBgCriticalPrimary
-    public let bgActionSecondaryPressed = compound.colorBgActionSecondaryPressed
-    public let bgActionSecondaryHovered = compound.colorBgActionSecondaryHovered
-    public let bgActionSecondaryRest = compound.colorBgActionSecondaryRest
-    public let bgActionPrimaryDisabled = compound.colorBgActionPrimaryDisabled
-    public let bgActionPrimaryPressed = compound.colorBgActionPrimaryPressed
-    public let bgActionPrimaryHovered = compound.colorBgActionPrimaryHovered
-    public let bgActionPrimaryRest = compound.colorBgActionPrimaryRest
-    // public let bgCanvasDefaultLevel1 = compound.colorBgCanvasDefaultLevel1
-    public let bgCanvasDisabled = compound.colorBgCanvasDisabled
-    public let bgCanvasDefault = compound.colorBgCanvasDefault
-    public let bgSubtleSecondary = compound.colorBgSubtleSecondary
-    public let bgSubtlePrimary = compound.colorBgSubtlePrimary
-    public let textOnSolidPrimary = compound.colorTextOnSolidPrimary
-    public let textInfoPrimary = compound.colorTextInfoPrimary
-    public let textSuccessPrimary = compound.colorTextSuccessPrimary
-    public let textCriticalPrimary = compound.colorTextCriticalPrimary
-    public let textLinkExternal = compound.colorTextLinkExternal
-    public let textActionAccent = compound.colorTextActionAccent
-    public let textActionPrimary = compound.colorTextActionPrimary
-    public let textDisabled = compound.colorTextDisabled
-    public let textPlaceholder = compound.colorTextPlaceholder
-    public let textSecondary = compound.colorTextSecondary
-    public let textPrimary = compound.colorTextPrimary
+    public subscript(dynamicMember keyPath: KeyPath<CompoundUIColorTokens, UIColor>) -> UIColor {
+        return tokens[keyPath: keyPath]
+    }
     
     // MARK: - Elevation Tokens
     // This is a workaround until they are generated correctly
     
-    public let bgSubtleSecondaryLevel0 = UIColor { $0.isLight ? compound.colorGray300 : compound.colorThemeBg }
-    public let bgCanvasDefaultLevel1 = UIColor { $0.isLight ? compound.colorThemeBg : compound.colorGray300 }
+    public let bgSubtleSecondaryLevel0 = UIColor { $0.isLight ? coreTokens.gray300 : coreTokens.themeBg }
+    public let bgCanvasDefaultLevel1 = UIColor { $0.isLight ? coreTokens.themeBg : coreTokens.gray300 }
     
     // MARK: - Awaiting Semantic Tokens
     
     /// This token is a placeholder and hasn't been finalised.
     @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _borderTextFieldFocused = compound.colorGray500
+    public let _bgCodeBlock = UIColor { $0.isLight ? coreTokens.gray500 : coreTokens.gray700 }
     /// This token is a placeholder and hasn't been finalised.
     @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _bgReactionButton = UIColor { $0.isLight ? compound.colorGray200 : compound.colorGray600 }
-    /// This token is a placeholder and hasn't been finalised.
-    @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _bgBubbleIncoming = UIColor { $0.isLight ? compound.colorGray300 : compound.colorGray400 }
-    /// This token is a placeholder and hasn't been finalised.
-    @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _bgBubbleOutgoing = UIColor { $0.isLight ? compound.colorGray400 : compound.colorGray500 }
-    /// This token is a placeholder and hasn't been finalised.
-    @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _bgCodeBlock = UIColor { $0.isLight ? compound.colorGray500 : compound.colorGray700 }
-    
-    /// This token is a placeholder and hasn't been finalised.
-    @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _borderInteractiveSecondaryAlpha = compound.colorAlphaGray600
-    /// This token is a placeholder and hasn't been finalised.
-    @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _bgSubtleSecondaryAlpha = compound.colorAlphaGray300
-    /// This token is a placeholder and hasn't been finalised.
-    @available(iOS, deprecated: 17.0, message: "This token should be generated by now.")
-    public let _bgCriticalSubtleAlpha = compound.colorAlphaRed300
+    public let _bgSubtleSecondaryAlpha = coreTokens.alphaGray300
 }
 
 private extension UITraitCollection {

--- a/Tests/CompoundTests/AvatarColorsTests.swift
+++ b/Tests/CompoundTests/AvatarColorsTests.swift
@@ -1,8 +1,17 @@
 //
-//  File.swift
-//  
+// Copyright 2023 New Vector Ltd
 //
-//  Created by Mauro Romito on 31/08/23.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/Tests/CompoundTests/OverrideColorTests.swift
+++ b/Tests/CompoundTests/OverrideColorTests.swift
@@ -1,0 +1,34 @@
+//
+// Copyright 2024 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+@testable import Compound
+import XCTest
+
+class OverrideColorTests: XCTestCase {
+    func testOverrideAndClear() {
+        let colors = CompoundColors()
+        let tokens = CompoundColorTokens()
+        XCTAssertEqual(colors.textPrimary, tokens.textPrimary)
+        
+        colors.override(\.textPrimary, with: .pink)
+        XCTAssertEqual(colors.textPrimary, .pink)
+        
+        colors.override(\.textPrimary, with: nil)
+        XCTAssertEqual(colors.textPrimary, tokens.textPrimary)
+    }
+}

--- a/Tests/CompoundTests/OverrideColorTests.swift
+++ b/Tests/CompoundTests/OverrideColorTests.swift
@@ -20,13 +20,25 @@ import Foundation
 import XCTest
 
 class OverrideColorTests: XCTestCase {
-    func testOverrideAndClear() {
+    func testSwiftUI() {
         let colors = CompoundColors()
         let tokens = CompoundColorTokens()
         XCTAssertEqual(colors.textPrimary, tokens.textPrimary)
         
         colors.override(\.textPrimary, with: .pink)
         XCTAssertEqual(colors.textPrimary, .pink)
+        
+        colors.override(\.textPrimary, with: nil)
+        XCTAssertEqual(colors.textPrimary, tokens.textPrimary)
+    }
+    
+    func testUIKit() {
+        let colors = CompoundUIColors()
+        let tokens = CompoundUIColorTokens()
+        XCTAssertEqual(colors.textPrimary, tokens.textPrimary)
+        
+        colors.override(\.textPrimary, with: .systemPink)
+        XCTAssertEqual(colors.textPrimary, .systemPink)
         
         colors.override(\.textPrimary, with: nil)
         XCTAssertEqual(colors.textPrimary, tokens.textPrimary)


### PR DESCRIPTION
Can be reviewed commit-by-commit, this PR adopts the [new token format](https://github.com/element-hq/compound-design-tokens/pull/86) for semantic tokens and uses these to allow runtime customisation of the colours. Some beautiful examples of this working:

| | |
| - | - |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-07-09 at 16 18 37](https://github.com/element-hq/compound-ios/assets/6060466/31e5bd7e-a227-4ee3-9a6b-549766b2592e) | ![Simulator Screenshot - iPhone 15 Pro - 2024-07-09 at 16 18 59](https://github.com/element-hq/compound-ios/assets/6060466/ec0341b6-11ce-4608-aa32-1892a5be5937) |