### PR TITLE
Fix the text colour of ListRow text fields when disabled.

### DIFF
--- a/Inspector/Inspector.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Inspector/Inspector.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "d2341adf332dc7341b4acad8761dff65e905d63c",
-        "version" : "1.16.2"
+        "revision" : "63d3b45dd249878a41c56274a748ca2c1c9c5230",
+        "version" : "1.17.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "d2341adf332dc7341b4acad8761dff65e905d63c",
-        "version" : "1.16.2"
+        "revision" : "63d3b45dd249878a41c56274a748ca2c1c9c5230",
+        "version" : "1.17.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .package(url: "https://github.com/siteline/SwiftUI-Introspect", from: "1.2.0"),
         .package(url: "https://github.com/SFSafeSymbols/SFSafeSymbols", from: "5.3.0"),
         .package(url: "https://github.com/BarredEwe/Prefire", from: "2.8.0"),
-        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.16.2")
+        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.1")
     ],
     targets: [
         .target(

--- a/Sources/Compound/List/ListRow.swift
+++ b/Sources/Compound/List/ListRow.swift
@@ -26,6 +26,8 @@ public enum ListRowPadding {
 }
 
 public struct ListRow<Icon: View, DetailsIcon: View, CustomContent: View, SelectionValue: Hashable>: View {
+    @Environment(\.isEnabled) private var isEnabled
+    
     let label: ListRowLabel<Icon>
     let details: ListRowDetails<DetailsIcon>?
     
@@ -116,6 +118,7 @@ public struct ListRow<Icon: View, DetailsIcon: View, CustomContent: View, Select
                     .compoundTextFieldPlaceholder()
             }
             .tint(.compound.iconAccentTertiary)
+            .foregroundStyle(isEnabled ? .compound.textPrimary : .compound.textDisabled)
             .listRowInsets(EdgeInsets(top: 11,
                                       leading: ListRowPadding.horizontal,
                                       bottom: 11,
@@ -415,6 +418,9 @@ public struct ListRow_Previews: PreviewProvider, PrefireProvider {
                     .padding(.horizontal, 16)
                     .padding(.vertical, 20)
             })
+            ListRow(label: .plain(title: "Placeholder"),
+                    kind: .textField(text: .constant("This is a disabled text field"), axis: .vertical))
+            .disabled(true)
             ListRow(label: .plain(title: "Placeholder"),
                     kind: .textField(text: .constant(""), axis: .vertical))
             .lineLimit(4...)


### PR DESCRIPTION
They now correctly use `.textDisabled` (and `.textPrimary` when enabled).