### PR TITLE
Update the stroke colour of the secondary button style to match Figma.

### DIFF
--- a/Sources/Compound/BaseStyles/CompoundButtonStyle.swift
+++ b/Sources/Compound/BaseStyles/CompoundButtonStyle.swift
@@ -107,12 +107,12 @@ public struct CompoundButtonStyle: ButtonStyle {
                 .compositingGroup()
                 .opacity(configuration.isPressed ? pressedOpacity : 1)
             } else {
-                Capsule().stroke(buttonColor(configuration: configuration))
+                Capsule().stroke(strokeColor(configuration: configuration))
             }
         case .primary:
-            Capsule().fill(buttonColor(configuration: configuration))
+            Capsule().fill(fillColor(configuration: configuration))
         case .secondary:
-            Capsule().stroke(buttonColor(configuration: configuration))
+            Capsule().stroke(strokeColor(configuration: configuration))
         case .plain:
             EmptyView()
         }
@@ -127,12 +127,20 @@ public struct CompoundButtonStyle: ButtonStyle {
         }
     }
 
-    private func buttonColor(configuration: Self.Configuration) -> Color {
+    private func fillColor(configuration: Self.Configuration) -> Color {
         guard isEnabled else { return .compound.bgActionPrimaryDisabled }
         if configuration.role == .destructive {
             return .compound.bgCriticalPrimary.opacity(configuration.isPressed ? pressedOpacity : 1)
         } else {
             return configuration.isPressed ? .compound.bgActionPrimaryPressed : .compound.bgActionPrimaryRest
+        }
+    }
+    
+    private func strokeColor(configuration: Self.Configuration) -> Color {
+        if configuration.role == .destructive {
+            return .compound.borderCriticalPrimary.opacity(configuration.isPressed ? pressedOpacity : 1)
+        } else {
+            return .compound.borderInteractiveSecondary.opacity(configuration.isPressed ? pressedOpacity : 1)
         }
     }
     


### PR DESCRIPTION
Our secondary buttons weren't using the correct border colour, this PR fixes that.

| Before | After |
| - | - |
| <img width="375" alt="old" src="https://github.com/user-attachments/assets/1ce45f35-99b2-4e58-999b-8255d8b89b6d"> | <img width="375" alt="new" src="https://github.com/user-attachments/assets/4f57d4ee-5966-42a4-bb49-06b521b215b2"> |
