### PR TITLE
Underline plain buttons when button shapes are enabled.

### DIFF
--- a/Sources/Compound/BaseStyles/CompoundButtonStyle.swift
+++ b/Sources/Compound/BaseStyles/CompoundButtonStyle.swift
@@ -21,6 +21,7 @@ public extension ButtonStyle where Self == CompoundButtonStyle {
 public struct CompoundButtonStyle: ButtonStyle {
     @Environment(\.isEnabled) private var isEnabled
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityShowButtonShapes) private var accessibilityShowButtonShapes
     
     var kind: Kind
     public enum Kind {
@@ -76,15 +77,20 @@ public struct CompoundButtonStyle: ButtonStyle {
     private var pressedOpacity: Double {
         colorScheme == .light ? 0.3 : 0.6
     }
+    
+    private var isUnderlined: Bool {
+        kind == .plain && accessibilityShowButtonShapes
+    }
 
     public func makeBody(configuration: Self.Configuration) -> some View {
         configuration.label
+            .font(.compound.bodyLGSemibold)
+            .underline(isUnderlined)
+            .multilineTextAlignment(.center)
+            .foregroundColor(textColor(configuration: configuration))
             .padding(.horizontal, horizontalPadding)
             .padding(.vertical, verticalPadding)
             .frame(maxWidth: maxWidth)
-            .font(.compound.bodyLGSemibold)
-            .foregroundColor(textColor(configuration: configuration))
-            .multilineTextAlignment(.center)
             .background {
                 makeBackground(configuration: configuration)
             }


### PR DESCRIPTION
Enabling the Button Shapes accessibility option will now underline our `plain` button style (which we use for both the Tertiary and Text Link) components as we haven't updated for this distinction yet.

| Button Shapes on | Button Shapes off |
| - | - |
| ![IMG_9F41B7C3EF57-1](https://github.com/user-attachments/assets/d03fb138-b9f4-4199-9bdd-9c3127a151ca) | ![IMG_B8CDAB240E4F-1](https://github.com/user-attachments/assets/c9a340fe-a8ba-40a4-b5dd-7798b8a43961) |
