### PR TITLE
Fix the send button when using Dynamic Type

### DIFF
--- a/Sources/Compound/Buttons/SendButton.swift
+++ b/Sources/Compound/Buttons/SendButton.swift
@@ -26,9 +26,9 @@ public struct SendButton: View {
     
     public var body: some View {
         Button(action: action) {
-            CompoundIcon(\.sendSolid)
+            CompoundIcon(\.sendSolid, size: .medium, relativeTo: .compound.headingLG)
                 .foregroundStyle(iconColor)
-                .padding(6)
+                .scaledPadding(6, relativeTo: .compound.headingLG)
                 .background { buttonShape }
                 .environment(\.colorScheme, colorSchemeOverride)
                 .compositingGroup()

--- a/Sources/Compound/Fonts/CompoundFonts.swift
+++ b/Sources/Compound/Fonts/CompoundFonts.swift
@@ -32,3 +32,21 @@ public struct CompoundFonts {
     public let headingXL = Font.largeTitle
     public let headingXLBold = Font.largeTitle.bold()
 }
+
+public extension Font.TextStyle {
+    /// The text styles used by Element as defined in Compound Design Tokens.
+    static let compound = CompoundTextStyles()
+}
+
+/// A manual mapping of the Compound font styles to iOS text styles. This is useful
+/// for `@ScaledMetric` along with modifiers such as `scaledPadding` etc.
+public struct CompoundTextStyles {
+    public let bodyXS = Font.TextStyle.caption
+    public let bodySM = Font.TextStyle.footnote
+    public let bodyMD = Font.TextStyle.subheadline
+    public let bodyLG = Font.TextStyle.body
+    public let headingSM = Font.TextStyle.title3
+    public let headingMD = Font.TextStyle.title2
+    public let headingLG = Font.TextStyle.title
+    public let headingXL = Font.TextStyle.largeTitle
+}

--- a/Sources/Compound/Layout/ScaledFrameModifier.swift
+++ b/Sources/Compound/Layout/ScaledFrameModifier.swift
@@ -1,0 +1,58 @@
+//
+// Copyright 2023, 2024 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+// Please see LICENSE in the repository root for full details.
+//
+
+import SwiftUI
+
+public extension View {
+    /// Positions this view within an invisible frame with a square size that scales relative to the user's selected font size.
+    func scaledFrame(size: CGFloat, alignment: Alignment = .center, relativeTo textStyle: Font.TextStyle = .body) -> some View {
+        scaledFrame(width: size, height: size, alignment: alignment, relativeTo: textStyle)
+    }
+    
+    /// Positions this view within an invisible frame with a size that scales relative to the user's selected font size.
+    func scaledFrame(width: CGFloat, height: CGFloat, alignment: Alignment = .center, relativeTo textStyle: Font.TextStyle = .body) -> some View {
+        modifier(ScaledFrameModifier(width: width, height: height, alignment: alignment, relativeTo: textStyle))
+    }
+}
+
+private struct ScaledFrameModifier: ViewModifier {
+    @ScaledMetric var width: CGFloat
+    @ScaledMetric var height: CGFloat
+    let alignment: Alignment
+    
+    init(width: CGFloat, height: CGFloat, alignment: Alignment, relativeTo textStyle: Font.TextStyle) {
+        _width = ScaledMetric(wrappedValue: width, relativeTo: textStyle)
+        _height = ScaledMetric(wrappedValue: height, relativeTo: textStyle)
+        self.alignment = alignment
+    }
+    
+    func body(content: Content) -> some View {
+        content.frame(width: width, height: height, alignment: alignment)
+    }
+}
+
+// MARK: - Previews
+
+import Prefire
+
+struct ScaledFrameModifier_Previews: PreviewProvider, PrefireProvider {
+    static var previews: some View {
+        VStack {
+            ForEach(DynamicTypeSize.allCases, id: \.self) { size in
+                likeButtonLabel
+                    .dynamicTypeSize(size)
+            }
+        }
+    }
+    
+    static var likeButtonLabel: some View {
+        Image(systemSymbol: .heartCircleFill)
+            .resizable()
+            .foregroundStyle(.compound.iconAccentTertiary)
+            .scaledFrame(size: 24, relativeTo: .title)
+    }
+}

--- a/Sources/Compound/Layout/ScaledOffsetModifier.swift
+++ b/Sources/Compound/Layout/ScaledOffsetModifier.swift
@@ -1,0 +1,55 @@
+//
+// Copyright 2024 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+// Please see LICENSE in the repository root for full details.
+//
+
+import SwiftUI
+
+public extension View {
+    /// Offset this view by the specified horizontal and vertical distances, scaled relative to the user's selected font size.
+    func scaledOffset(x: CGFloat = 0, y: CGFloat = 0, relativeTo textStyle: Font.TextStyle = .body) -> some View {
+        modifier(ScaledOffsetModifier(x: x, y: y, relativeTo: textStyle))
+    }
+}
+
+private struct ScaledOffsetModifier: ViewModifier {
+    @ScaledMetric var x: CGFloat
+    @ScaledMetric var y: CGFloat
+    
+    init(x: CGFloat, y: CGFloat, relativeTo textStyle: Font.TextStyle) {
+        _x = ScaledMetric(wrappedValue: x, relativeTo: textStyle)
+        _y = ScaledMetric(wrappedValue: y, relativeTo: textStyle)
+    }
+    
+    func body(content: Content) -> some View {
+        content.offset(x: x, y: y)
+    }
+}
+
+
+// MARK: - Previews
+
+import Prefire
+
+struct ScaledOffsetModifier_Previews: PreviewProvider, PrefireProvider {
+    static var previews: some View {
+        VStack {
+            ForEach(DynamicTypeSize.allCases, id: \.self) { size in
+                verifiedUserComposite
+                    .dynamicTypeSize(size)
+            }
+        }
+    }
+    
+    static var verifiedUserComposite: some View {
+        CompoundIcon(\.userSolid)
+            .foregroundStyle(.compound.iconAccentTertiary)
+            .overlay {
+                CompoundIcon(\.verified, size: .custom(10), relativeTo: .body)
+                    .scaledOffset(x: 6, y: 6)
+                    .foregroundStyle(.compound.borderInfoSubtle)
+            }
+    }
+}

--- a/Sources/Compound/Layout/ScaledPaddingModifier.swift
+++ b/Sources/Compound/Layout/ScaledPaddingModifier.swift
@@ -1,0 +1,56 @@
+//
+// Copyright 2023, 2024 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+// Please see LICENSE in the repository root for full details.
+//
+
+import SwiftUI
+
+public extension View {
+    /// Adds an equal padding amount to all edges of this view, scaled relative to the user's selected font size.
+    func scaledPadding(_ length: CGFloat, relativeTo textStyle: Font.TextStyle = .body) -> some View {
+        scaledPadding(.all, length, relativeTo: textStyle)
+    }
+    
+    /// Adds an equal padding amount to specific edges of this view, scaled relative to the user's selected font size.
+    func scaledPadding(_ edges: Edge.Set, _ length: CGFloat, relativeTo textStyle: Font.TextStyle = .body) -> some View {
+        modifier(ScaledPaddingModifier(edges: edges, length: length, textStyle: textStyle))
+    }
+}
+
+private struct ScaledPaddingModifier: ViewModifier {
+    let edges: Edge.Set
+    @ScaledMetric var length: CGFloat
+    
+    init(edges: Edge.Set, length: CGFloat, textStyle: Font.TextStyle) {
+        self.edges = edges
+        _length = ScaledMetric(wrappedValue: length, relativeTo: textStyle)
+    }
+    
+    func body(content: Content) -> some View {
+        content.padding(edges, length)
+    }
+}
+
+// MARK: - Previews
+
+import Prefire
+
+struct ScaledPaddingModifier_Previews: PreviewProvider, PrefireProvider {
+    static var previews: some View {
+        VStack {
+            ForEach(DynamicTypeSize.allCases, id: \.self) { size in
+                userProfileButtonLabel
+                    .dynamicTypeSize(size)
+            }
+        }
+    }
+    
+    static var userProfileButtonLabel: some View {
+        CompoundIcon(\.userProfile, size: .medium, relativeTo: .title)
+            .foregroundStyle(.compound.iconOnSolidPrimary)
+            .scaledPadding(6, relativeTo: .title)
+            .background(.compound.bgAccentRest, in: Circle())
+    }
+}


### PR DESCRIPTION
Compared to the rest of the ComposerToolbar, the button wasn't scaling relative to the `.title` text style. This PR
- Adds all of our `scaledPadding`/`Offset`/`Frame` modifiers.
    - Along with some snapshot tests of each proving they work.
- Adds a compound text style mapping.
- Uses `.compound.headingLG` to scale the button (which maps to `.title`).