### PR TITLE
Fix a colour token in light mode on the SendButton.

### DIFF
--- a/Sources/Compound/Buttons/SendButton.swift
+++ b/Sources/Compound/Buttons/SendButton.swift
@@ -15,9 +15,12 @@ public struct SendButton: View {
     /// The action to perform when the user triggers the button.
     public let action: () -> Void
     
-    private var iconColor: Color { isEnabled ? .compound.iconPrimary : .compound.iconQuaternary }
+    private var iconColor: Color {
+        guard isEnabled else { return .compound.iconQuaternary }
+        return colorScheme == .light ? .compound.iconOnSolidPrimary : .compound.iconPrimary
+    }
+    
     private var gradient: Gradient { isEnabled ? enabledGradient : .init(colors: [.clear]) }
-    private var colorSchemeOverride: ColorScheme { isEnabled ? .dark : colorScheme }
     
     /// This is a custom gradient used for this button, the colours don't come from our core tokens
     /// and aren't reactive to light/dark mode or high contrast, so it is hard coded in here.
@@ -39,7 +42,6 @@ public struct SendButton: View {
                 .foregroundStyle(iconColor)
                 .scaledPadding(6, relativeTo: .compound.headingLG)
                 .background { buttonShape }
-                .environment(\.colorScheme, colorSchemeOverride)
                 .compositingGroup()
         }
     }


### PR DESCRIPTION
Use `light/icon/on-solid-primary` instead of `dark/icon/primary` in light mode. This also removes the need to override the colour scheme now seeing as the gradient isn't using reactive colours either.

It's hard to see but there is a difference to the light mode compared to #130:

<img width="172" alt="test_sendButton-iPhone-16 1" src="https://github.com/user-attachments/assets/5f9169c1-a3d5-4d1b-9380-e214d336a7cc">
