### PR TITLE
Update design tokens.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/compound-design-tokens",
       "state" : {
-        "revision" : "a6e96fb4436a4945423a8c068001093af4b7b315",
-        "version" : "3.0.1"
+        "revision" : "3e3f83f61ad48acc8532636a773ccdeafd3834fe",
+        "version" : "4.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .library(name: "Compound", targets: ["Compound"])
     ],
     dependencies: [
-        .package(url: "https://github.com/element-hq/compound-design-tokens", exact: "3.0.1"),
+        .package(url: "https://github.com/element-hq/compound-design-tokens", exact: "4.0.0"),
         .package(url: "https://github.com/siteline/SwiftUI-Introspect", from: "1.3.0"),
         .package(url: "https://github.com/SFSafeSymbols/SFSafeSymbols", from: "5.3.0"),
         .package(url: "https://github.com/BarredEwe/Prefire", from: "2.10.0"),

--- a/Sources/Compound/List/ListRowLabel.swift
+++ b/Sources/Compound/List/ListRowLabel.swift
@@ -182,7 +182,7 @@ public struct ListRowLabel<Icon: View>: View {
             if let description {
                 HStack(alignment: .top, spacing: 4) {
                     if role == .error {
-                        CompoundIcon(\.error, size: .xSmall, relativeTo: .compound.bodySM)
+                        CompoundIcon(\.errorSolid, size: .xSmall, relativeTo: .compound.bodySM)
                             .foregroundStyle(.compound.iconCriticalPrimary)
                     }
                     


### PR DESCRIPTION
There's a new icon export workflow so the curves are simplified in a different way. There's nothing visually different but the snapshots all needed updating.

Oh `error` → `errorSolid` on the icons too as `error` is now a new outlined variant.