### PR TITLE
Fix: accessibility on toggles and pickers in lists

### DIFF
--- a/Sources/Compound/List/ListRow.swift
+++ b/Sources/Compound/List/ListRow.swift
@@ -84,6 +84,8 @@ public struct ListRow<Icon: View, DetailsIcon: View, CustomContent: View, Select
             } label: {
                 label
             }
+            // Due to a limitation of LabeledContent, we need to manually combine them for accessibility
+            .accessibilityElement(children: .combine)
         case .toggle(let binding):
             LabeledContent {
                 // Note: VoiceOver label already provided.
@@ -95,6 +97,8 @@ public struct ListRow<Icon: View, DetailsIcon: View, CustomContent: View, Select
                 label
             }
             .padding(.trailing, ListRowPadding.horizontal)
+            // Due to a limitation of LabeledContent, we need to manually combine them for accessibility
+            .accessibilityElement(children: .combine)
         case .inlinePicker(let selection, let items):
             ListInlinePicker(title: label.title ?? "",
                              selection: selection,


### PR DESCRIPTION
`LabeledContent` did not properly group accessibility elements by default, so we need to manually apply the modifier ourselves.