### PR TITLE
Use the generated asymmetric tokens 🎉

### DIFF
--- a/Inspector/Inspector.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Inspector/Inspector.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/compound-design-tokens.git",
       "state" : {
-        "revision" : "00a392cf3e907fb2ebc49a9590f7a0a97c175c0f",
-        "version" : "5.0.0"
+        "revision" : "b0addc0775526685ad96fd9ef9c04b2de4456314",
+        "version" : "5.0.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/element-hq/compound-design-tokens",
       "state" : {
-        "revision" : "00a392cf3e907fb2ebc49a9590f7a0a97c175c0f",
-        "version" : "5.0.0"
+        "revision" : "b0addc0775526685ad96fd9ef9c04b2de4456314",
+        "version" : "5.0.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .library(name: "Compound", targets: ["Compound"])
     ],
     dependencies: [
-        .package(url: "https://github.com/element-hq/compound-design-tokens", exact: "5.0.0"),
+        .package(url: "https://github.com/element-hq/compound-design-tokens", exact: "5.0.1"),
         // .package(path: "../compound-design-tokens"),
         .package(url: "https://github.com/siteline/SwiftUI-Introspect", from: "1.3.0"),
         .package(url: "https://github.com/SFSafeSymbols/SFSafeSymbols", from: "6.2.0"),

--- a/Sources/Compound/Colors/CompoundColors.swift
+++ b/Sources/Compound/Colors/CompoundColors.swift
@@ -93,19 +93,6 @@ public class CompoundColors {
     public let _bgEmptyItemAlpha = coreTokens.alphaGray500
 }
 
-public extension CompoundColorTokens {
-    // MARK: - Asymmetric tokens
-    // This is a workaround until they are generated correctly
-    
-    var bgSubtleSecondaryLevel0: Color { Color(UIColor { $0.isLight ? UIColor(CompoundCoreColorTokens.gray300) : UIColor(CompoundCoreColorTokens.themeBg) }) }
-    var bgCanvasDefaultLevel1: Color { Color(UIColor { $0.isLight ? UIColor(CompoundCoreColorTokens.themeBg) : UIColor(CompoundCoreColorTokens.gray300) }) }
-    
-    var gradientActionStop1: Color { Color(UIColor { $0.isLight ? UIColor(CompoundCoreColorTokens.green500) : UIColor(CompoundCoreColorTokens.green1100) }) }
-    var gradientActionStop2: Color { Color(UIColor { $0.isLight ? UIColor(CompoundCoreColorTokens.green700) : UIColor(CompoundCoreColorTokens.green900) }) }
-    var gradientActionStop3: Color { Color(UIColor { $0.isLight ? UIColor(CompoundCoreColorTokens.green900) : UIColor(CompoundCoreColorTokens.green700) }) }
-    var gradientActionStop4: Color { Color(UIColor { $0.isLight ? UIColor(CompoundCoreColorTokens.green1100) : UIColor(CompoundCoreColorTokens.green500) }) }
-}
-
 private extension UITraitCollection {
     /// Whether or not the trait collection contains a `userInterfaceStyle` of `.light`.
     var isLight: Bool { userInterfaceStyle == .light }

--- a/Sources/Compound/Colors/CompoundUIColors.swift
+++ b/Sources/Compound/Colors/CompoundUIColors.swift
@@ -37,12 +37,6 @@ public class CompoundUIColors {
         overrides[keyPath] = color
     }
     
-    // MARK: - Elevation Tokens
-    // This is a workaround until they are generated correctly
-    
-    public let bgSubtleSecondaryLevel0 = UIColor { $0.isLight ? coreTokens.gray300 : coreTokens.themeBg }
-    public let bgCanvasDefaultLevel1 = UIColor { $0.isLight ? coreTokens.themeBg : coreTokens.gray300 }
-    
     // MARK: - Awaiting Semantic Tokens
     
     /// This token is a placeholder and hasn't been finalised.


### PR DESCRIPTION
https://github.com/element-hq/compound-design-tokens/pull/170 fixed the bug where asymmetric tokens weren't generated properly. This means we can get rid of those manually created ones and overrides will all work properly!